### PR TITLE
Add ability to split tracking message to smaller parts

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "grimes",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "documents": [
     {
       "name": "README",

--- a/lib/grimes/throttle.rb
+++ b/lib/grimes/throttle.rb
@@ -53,8 +53,7 @@ module Grimes
     def track_data
       begin
         result = calculate_all_paths_from_threads
-        parts_num = [(result.size/limit.to_f).ceil, 1].max
-        split_into(result, parts_num).each do |part|
+        split_result(result, limit).each do |part|
           track_block&.call(part)
         end
         reset_all_paths
@@ -81,6 +80,12 @@ module Grimes
     end
 
     private
+
+    def split_result(result, limit)
+        parts_num = [(result.size/limit.to_f).ceil, 1].max
+        split_into(result, parts_num)
+    end
+
     def split_into(hash, divisions)
       count = 0
       result = hash.inject([]) do |final, key_value|

--- a/lib/grimes/throttle.rb
+++ b/lib/grimes/throttle.rb
@@ -2,11 +2,12 @@ require 'grimes/utils/merge_file_path'
 
 module Grimes
   class Throttle
-    attr_reader :throttle_time, :track_block, :thread
+    attr_reader :throttle_time, :track_block, :thread, :limit
 
-    def initialize(throttle_time, track_block)
+    def initialize(throttle_time, track_block, limit)
       @throttle_time = throttle_time
       @track_block = track_block
+      @limit = limit
     end
 
     def start
@@ -36,8 +37,8 @@ module Grimes
       Thread.current[:grimes_all_paths] = all_paths
     end
 
-    def self.start(time, track_block)
-      @instance = new(time, track_block)
+    def self.start(time, track_block, limit = 10000)
+      @instance = new(time, track_block, limit)
       @instance.start
     end
 
@@ -52,7 +53,10 @@ module Grimes
     def track_data
       begin
         result = calculate_all_paths_from_threads
-        track_block&.call(result)
+        parts_num = [(result.size/limit.to_f).ceil, 1].max
+        split_into(result, parts_num).each do |part|
+          track_block&.call(part)
+        end
         reset_all_paths
       rescue StandardError => e
         p e
@@ -74,6 +78,18 @@ module Grimes
         all_paths = Utils::MergeFilePath.merge_paths(all_paths, paths)
       end
       all_paths
+    end
+
+    private
+    def split_into(hash, divisions)
+      count = 0
+      result = hash.inject([]) do |final, key_value|
+        final[count%divisions] ||= {}
+        final[count%divisions][key_value[0]] = key_value[1]
+        count += 1
+        final
+      end
+      result
     end
   end
 end

--- a/spec/throttle_spec.rb
+++ b/spec/throttle_spec.rb
@@ -74,4 +74,15 @@ describe Grimes::Throttle do
     end
     expect(log_result).to eq({ 'file_path' => { count: 1, extra_data: { data: 1 }} })
   end
+
+  describe 'passing files limit per parts' do
+    it 'breaks files list to smallers parts' do
+      described_class.start(time, track_block, 2)
+      10.times.each do |i|
+        described_class.track("file_path_#{i}", { data: 1 })
+      end
+      sleep 0.2
+      expect(track_log.compact.count).to eq(5)
+    end
+  end
 end

--- a/spec/throttle_spec.rb
+++ b/spec/throttle_spec.rb
@@ -13,10 +13,23 @@ describe Grimes::Throttle do
 
   after { described_class.flush_buffer }
 
-  it 'can start and call track_block every "time" second pass' do
-    described_class.start(time, track_block)
-    sleep 0.2
-    expect(track_log.size >= 2).to be_truthy
+  context 'track is call' do
+    it 'can start and call track_block every "time" second pass' do
+      described_class.start(time, track_block)
+      described_class.track('file_path_1')
+      sleep 0.1
+      described_class.track('file_path_1')
+      sleep 0.1
+      expect(track_log.size >= 2).to be_truthy
+    end
+  end
+
+  context 'nothing tracked' do
+    it 'can start and call track_block every "time" second pass' do
+      described_class.start(time, track_block)
+      sleep 0.2
+      expect(track_log.size).to eq(0)
+    end
   end
 
   it 'track path info and call track_block with that data' do


### PR DESCRIPTION
# Summary
Since logdna has a limitation on a message size, they auto split big message to smaller messages.
That make LogDNA cannot parse our json format. To fix it, I add abilty to split our message to smaller parts so LogDNA can still parse it.