### PR TITLE
Df/fix missing substring for grape api file path

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "grimes",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "documents": [
     {
       "name": "README",

--- a/lib/grimes/grape_tracking_middleware.rb
+++ b/lib/grimes/grape_tracking_middleware.rb
@@ -5,7 +5,7 @@ module Grimes
     def before
       route = self.env["api.endpoint"].routes.first
       action = get_controller_action(route)
-      source_location = get_controller_file_location(route)
+      source_location = get_controller_file_location(route).sub(Grimes.config.app_root, '')
       callback_block = Grimes.config.call_grape_controller_block
       callback_block&.call({ file_path: source_location, action_name: action })
     rescue StandardError => e


### PR DESCRIPTION
Full file path from grape API should be substring to application file path. For example: Full file path: `/app/app/api/employment_hero/v1/members/leave_balances.rb` will be replaced with `app/api/employment_hero/v1/members/leave_balances.rb`